### PR TITLE
pregexp-match no longer exists in racket 5.2.

### DIFF
--- a/strings.arc
+++ b/strings.arc
@@ -227,7 +227,7 @@
 ; Import Scheme's regular expressions
 (= re $.regexp)
 (def re-match (rx s) ($.regexp-match rx s))
-(def pre-match (rx s) ($.pregexp-match rx s))
+(= pre-match re-match)
 (= re-match? [no:no:re-match _1 _2])
 (= re-pos $.regexp-match-positions)
 (= re-subst $.regexp-replace)


### PR DESCRIPTION
`regexp-match` (`re-match` in anarki) has been updated to handle expressions produced by both `regexp` (`re`) and `pregexp`.

Do most anarki users run ontop of older versions of racket or has this remained unchanged because nobody else has run into this before now?
