### PR TITLE
Append sitename to the title tag of the RSS feed items

### DIFF
--- a/news.arc
+++ b/news.arc
@@ -2252,7 +2252,7 @@ function vote(node) {
       (each s stories
         (tag item
           (let comurl (+ site-url* (item-url s!id))
-            (tag title    (pr (eschtml s!title)))
+            (tag title    (pr (eschtml s!title) " (" (sitename s!url) ")"))
             (tag link     (pr (if (blank s!url) comurl (eschtml s!url))))
             (tag comments (pr comurl))
             (tag description


### PR DESCRIPTION
When I browse HN in my RSS Reader instead of the website, I miss having
the sitename clue.  Sometimes I will read something based off of the
domain (e.g., "kalzumeus.com"), even if the title doesn't seem interesting.
