### PR TITLE
Fixed a bug that an error occurs on (write '(1 2 . 3))

### DIFF
--- a/arc.arc
+++ b/arc.arc
@@ -1834,7 +1834,8 @@
   x)
 
 (defmethod serialize (x) cons
-  (map serialize x))
+  (cons (serialize (car x))
+        (serialize (cdr x))))
 
 (defmethod serialize (x) table
   (list 'table


### PR DESCRIPTION
When I used (write) function, an error occurred as follows.

arc> (write '(1 2 . 3))
Error: "Can't take car of 3"

The bug is fixed by this commit.
