### PR TITLE
Use 'greadlink' instead of non gnu 'readlink' when running on OSX.

### DIFF
--- a/arc.sh
+++ b/arc.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 
-arc_dir=$(dirname "$(readlink -f "$0")")
+
+if [ $(uname) == "Darwin" ]; then
+    if which -s greadlink; then
+        arc_dir=$(dirname "$(greadlink -f "$0")")
+    else
+        echo 'Please do "brew install coreutils".'
+        exit 1
+    fi
+else
+    arc_dir=$(dirname "$(readlink -f "$0")")
+fi
 
 if [ "$1" = "--no-rl" ]; then
     shift


### PR DESCRIPTION
This fixes anarki's startup on OSX.
