### PR TITLE
Add optional predicate-based typing

### DIFF
--- a/arc.arc
+++ b/arc.arc
@@ -578,9 +578,18 @@ This is the most reliable way to check for presence, even when searching for nil
   (mem 6 '(2 4 5 6 7))
   (6 7))
 
+; Optional predicate-based typing
+
+(assign types* (table))
+
+(mac deftype (name . body)
+  `(= (types* ',name) (fn (_) ,@body)))
+
 (def isa (x y)
-"Is 'x' of type 'y'?"
-  (is (type x) y))
+  (if (is type.x y) t
+      (let valid nil
+	(maptable (fn (k v) (if (is k y) (= valid t))) types*)
+	(and valid ((types* y) x)))))
 
 (document builtin coerce (x type)
 "Try to turn 'x' into a value of a different 'type'.")

--- a/arc.arc
+++ b/arc.arc
@@ -583,9 +583,11 @@ This is the most reliable way to check for presence, even when searching for nil
 (assign types* (table))
 
 (mac deftype (name . body)
+"Declares a new predicate-based type that can be checked with 'isa'."
   `(= (types* ',name) (fn (_) ,@body)))
 
 (def isa (x y)
+"Is 'x' of type 'y'?"
   (if (is type.x y) t
       (let valid nil
 	(maptable (fn (k v) (if (is k y) (= valid t))) types*)

--- a/arc.cmd
+++ b/arc.cmd
@@ -1,2 +1,0 @@
-@echo off
-call "C:/Program Files/Racket/Racket.exe" -f C:/anarki/boot.scm -e (tl) %*

--- a/arc.cmd
+++ b/arc.cmd
@@ -1,0 +1,2 @@
+@echo off
+call "C:/Program Files/Racket/Racket.exe" -f C:/anarki/boot.scm -e (tl) %*


### PR DESCRIPTION
This adds optional predicate-dispatch typing to anarki. New definitions include and table named "types*" that store anonymous predicate functions and a macro named "deftype" that defines a new predicate in the "types*" table. It has been integrated with the "isa" function to provide dual-functionality: the old way of "isa" still works, but if an object is not the type specified to "isa", the "types*" table is checked to see if a predicate is bound to that particular type name. Example:

(deftype positive-num (and (or (isa _ 'num) (isa _ 'int)) (> _ 0)))
(isa 1 'int) => t
(isa 1 'num) => nil
(isa 1 'positive-num) => t
(isa 1.5 'positive-num) => t
(isa -1 'positive-num) => nil
(isa 0 'positive-num) => nil