### PR TITLE
Make "point", hence loops in general, enormously cheaper with call/ec…

### DIFF
--- a/ac.scm
+++ b/ac.scm
@@ -853,6 +853,8 @@
 
 (xdef ccc call-with-current-continuation)
 
+(xdef call/ec call-with-escape-continuation)
+
 (xdef infile  open-input-file)
 
 (xdef outfile (lambda (f . args)

--- a/arc.arc
+++ b/arc.arc
@@ -410,9 +410,9 @@ For example, this prints numbers ad infinitum:
 (mac point (name . body)
 "Like [[do]], but may be exited by calling 'name' from within 'body'."
   (w/uniq (g p)
-    `(ccc (fn (,g)
-            (let ,name (fn ((o ,p)) (,g ,p))
-              ,@body)))))
+    `(call/ec (fn (,g)
+                (let ,name (fn ((o ,p)) (,g ,p))
+                  ,@body)))))
 
 ; Ac expands x:y:z into (compose x y z)
 ; The last arg (z above) cannot be a macro unless the form is in functional
@@ -3022,4 +3022,3 @@ Useful in higher-order functions, or to index into lists, strings, tables, etc."
 ; crazy that finding the top 100 nos takes so long:
 ;  (let bb (n-of 1000 (rand 50)) (time10 (bestn 100 > bb)))
 ;  time: 2237 msec.  -> now down to 850 msec
-


### PR DESCRIPTION
… instead of call/cc

Before:
arc> (each n '(1000 2000 4000 8000 16000 32000) (pr n " ") (time:repeat n nil))
1000 time: 13 msec.
2000 time: 35 msec.
4000 time: 130 msec.
8000 time: 711 msec.
16000 time: 3405 msec.
32000 time: 19372 msec.

After:
arc> (each n '(1000 2000 4000 8000 16000 32000) (pr n " ") (time:repeat n nil))
1000 time: 0 msec.
2000 time: 1 msec.
4000 time: 1 msec.
8000 time: 3 msec.
16000 time: 6 msec.
32000 time: 12 msec.