### PR TITLE
Fix test that makes remote request.

### DIFF
--- a/lib/client.arc.t
+++ b/lib/client.arc.t
@@ -37,7 +37,7 @@
                     (assert-same "Cookie: name=value; name2=value2; Expires=Wed, 09 Jun 2021;"
                                  (encode-cookies (list "name" "value" "name2" "value2" "Expires" "Wed, 09 Jun 2021")))))
        (suite send-request
-              (test ping-google
-                    (assert-same "HTTP/1.0 200 OK"
-                                 (caar (mkreq "www.google.com"))))))
+              (test ping-httpbin
+                    (assert-same "HTTP/1.1 200 OK"
+                                 (caar (mkreq "www.httpbin.org/status/200"))))))
 


### PR DESCRIPTION
Calling mkreq on google.com returns a 302. Relying on this to return a specific status code is not robust. This test is currently failing as the endpoint returns a 302. On the other hand httpbin.org has an endpoint to select a status code, so maybe this will do for the purpose of this test? Technically the HTTP version should also be allowed to change, but maybe this is fine for now?