### PR TITLE
Modified arc.sh for FreeBSD compatibility.

### DIFF
--- a/arc.sh
+++ b/arc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Put a symlink to this script somewhere in your path.
 #
 # To run an Arc program, pass it in followed by any args to it.
@@ -101,8 +101,7 @@ case $(uname) in
         ;;
 
     *)
-        echo "Sorry, this script doesn't run on your platform $(uname) yet. Please create a new issue at https://github.com/arclanguage/anarki/issues."
-        exit 1
+	arc_dir=$(pwd)
 esac
 
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
Modified catchall line to simply `arc_dir=$(pwd)` which allows execution on FreeBSD.

In addition, modified shebang line to `/usr/bin/env` so that users of an atypical bash location are able to easily execute the script.