### PR TITLE
fixed doctype issue

### DIFF
--- a/lib/news.arc
+++ b/lib/news.arc
@@ -404,7 +404,7 @@
 
 (mac npage (title . body)
   `(do 
-;   (prn "<!DOCTYPE html>")
+   (prn "<!DOCTYPE html>")
     (tag html
        (tag head
          (gentag meta "charset" "UTF-8")

--- a/lib/srv.arc
+++ b/lib/srv.arc
@@ -118,10 +118,10 @@
     (and (~posmatch ".." fname) ; for security
          (case (downcase (last (check (tokens fname #\.) ~single)))
            "gif"  "image/gif"
-           "jpg"  "image/jpg"
-           "jpeg" "image/jpg"
+           "jpg"  "image/jpeg"
+           "jpeg" "image/jpeg"
            "png"  "image/png"
-           "css"  "text/plain"
+           "css"  "text/css"
            "js"   "text/javascript"
            "txt"  "text/plain"
            "htm"  "text/html"

--- a/static/news.css
+++ b/static/news.css
@@ -62,5 +62,5 @@ supplied by pb
 */
 .vote { padding-left:2px; vertical-align:top; }
 .comment { margin-top:1ex; margin-bottom:1ex; color:black; }
-.vote IMG { border:0; margin: 3px 2px 3px 2px; }
+.vote IMG { border:0px; margin: 3px 2px 3px 2px; }
 .reply { font-size:smaller; text-decoration:underline !important; }


### PR DESCRIPTION
changed the doctype for css files from text/plain to text/css in srv.arc and uncommented the doctype, which works now. 
