### PR TITLE
removed blog and events, integrated editor and repl

### DIFF
--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,9 +1,9 @@
-(require '(lib/app.arc
- lib/prompt.arc
-; search.arc  search bar
-; events.arc  event calendar
-; blog.arc    community blogging
- ))
+(require "lib/app.arc")
+(require "lib/prompt.arc")
+(require "lib/files.arc")
+
+;(require (qualified-path "../events.arc"))
+;(require (qualified-path "../blog.arc"))
 
 
 (= this-site*    "Anarki"

--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,4 +1,10 @@
-(require 'lib/app.arc)
+(require '(lib/app.arc
+ lib/prompt.arc
+; search.arc  search bar
+; events.arc  event calendar
+; blog.arc    community blogging
+ ))
+
 
 (= this-site*    "Anarki"
    site-url*     "http://site.example.com";your domain name
@@ -541,7 +547,12 @@
       (tag (img src logo-url* alt 'a width 18 height 18
                 style "border:1px #@(hexrep border-color*) solid;")))))
 
-(= toplabels* '(nil "welcome" "new" "threads" "comments" "ask" "blog" "events" "*"))
+(= toplabels* '(nil "welcome" "new" 
+  "threads" "comments" 
+  "ask" 
+;  "blog" 
+;  "events" 
+  "*"))
 
 (= welcome-url* "welcome")
 
@@ -555,8 +566,18 @@
     (toplink "comments" "newcomments" label)
     (hook 'toprow user label)
     (toplink "ask" "ask" label)
+
+; in case anyone else was confused, 'posts* and 'events*
+; become bound if blog.arc and events.arc are included.
+
     (if (bound 'posts*) (toplink "blog" "blog" label))
     (if (bound 'events*) (toplink "events" "events" label))
+
+    (if (admin user) (do
+      (toplink "prompt" "prompt" label)
+      (pr "&nbsp;|&nbsp;")
+      (toplink "repl" "repl" label)))
+
     (when
       (and user (> (karma user) poll-threshold*))
       (toplink "poll" "newpoll" label))

--- a/apps/news/run-news.arc
+++ b/apps/news/run-news.arc
@@ -1,10 +1,4 @@
-(require '(
- news.arc   ; HN style app
- search.arc ; search bar
- events.arc ; event calendar
- blog.arc   ; community blogging
- lib/prompt.arc
-))
+(require 'news.arc)   ; HN style app
 
 (thread (nsv 8080)) ; run in a thread so repl remains usable
 (sleep 3)  ; wait for nsv's initial messages to appear before printing first prompt

--- a/lib/prompt.arc
+++ b/lib/prompt.arc
@@ -1,19 +1,25 @@
 ; Prompt: Web-based programming application.  4 Aug 06.
-(require 'lib/files.arc)
+(require '(
+  lib/files.arc
+  lib/srv.arc))
 
 ;(= appdir* (+ srvdir* "apps/"))
 
 (= appdir* (qualified-path (+ srvdir* "../../apps/")))
 
+; TODO: return a proper 404 error if no admin user
+; this might be a problem in general with routes
+; that exist, but can't resolve
 (defop prompt req
   (let user (get-user req)
     (if (admin user)
       (prompt-page user)
-      (pr "Sorry."))))
+        (pr "Unknown"))))
 
 (def prompt-page (user . msg)
   (ensure-dir appdir*)
   (ensure-dir (string appdir* user))
+;  (ensure-dir (string appdir* "public"))
   (whitepage
     (prbold "Prompt")
     (sp)
@@ -22,6 +28,7 @@
     (link "logout")
     (when msg (hspace 10) (apply pr msg))
     (br2)
+    
     (tag (table border 0 cellspacing 10)
       (each app (dir (+ appdir* user))
         (tr (td app)
@@ -97,10 +104,17 @@
 (defop repl req
   (if (admin (get-user req))
     (replpage req)
-    (pr "Sorry.")))
+    (pr "Unknown")))
 
+; user doesn't actually work here
 (def replpage (req)
   (whitepage
+  (prbold "Prompt")
+    (sp)
+    (hspace 20)
+;   (pr user " | ")
+    (link "logout")
+    (br2)
     (repl (readall (or (arg req "expr") "")) "repl")))
 
 (def repl (exprs url)


### PR DESCRIPTION
I commented out the blog and events pages for now, since that doesn't seem to be the default. The editor and repl will now appear in the top menu for logged in admins.

I also moved the includes for news into news itself, since it didn't make sense to me for the script starting news to also be responsible for its dependencies. 