### PR TITLE
Dev prompt/app editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ apps/*/tmp/
 
 apps/*/logs
 
+apps/managed/*
+
 # Let's not commit the unit-test.arc repo to the Anarki repo by
 # accident.
 /unit-test.arc/

--- a/apps/news/appeditor.arc
+++ b/apps/news/appeditor.arc
@@ -1,5 +1,3 @@
-; App Manager: Web-based programming application based on prompt.arc
-
 (require 'lib/files.arc)
 (require 'lib/srv.arc)
 

--- a/apps/news/appeditor.arc
+++ b/apps/news/appeditor.arc
@@ -23,7 +23,7 @@
     (link "logout")
 
     (when msg (hspace 10) (apply pr msg))
-    (pr hooks*)
+
     (br2)
     (aform (fn (req)
       (aif (goodname (arg req "app")) ; check if file exists

--- a/apps/news/appeditor.arc
+++ b/apps/news/appeditor.arc
@@ -1,0 +1,138 @@
+; App Manager: Web-based programming application based on prompt.arc
+
+(require '(
+  lib/files.arc
+  lib/srv.arc))
+
+(= mgappdir* (qualified-path (+ srvdir* "../../managed/")))
+   
+(defop editor req
+  (let user (get-user req)
+    (if (admin user)
+      (editor-page user)
+        (pr "Unknown"))))
+
+(def editor-page (user . msg)
+  
+  (ensure-dir mgappdir*)
+
+  (whitepage
+    (prbold "App Editor")
+    (sp)
+    (hspace 20)
+    (pr user " | ")
+    (link "logout")
+
+    (when msg (hspace 10) (apply pr msg))
+
+    (br2)
+    (aform (fn (req)
+      (aif (goodname (arg req "app")) ; check if file exists
+           (app-edit user it)
+           (editor-page user "Bad name.")))
+     
+    (tab (row "name:" (input "app") (submit "create app"))))
+
+    (tag (table border 0 cellspacing 10)
+      (each app (dir mgappdir*)
+        (tr (td app)
+            (td (ulink user 'edit   (app-edit user app)))
+            (td  (if (hooks* app)
+                  (ulink user 'unhook (app-unhook user app))
+                  (ulink user 'hook (app-hook user app))))
+            (td (ulink user 'run (app-page user app)))
+            (td (hspace 40)
+                (ulink user 'delete (app-delete user app))))))
+
+    (prbold "Repl")
+
+    
+    
+    (aform (fn (req) 
+      (do 
+        (each expr (readall (or (arg req "expr") ""))
+              (on-err (fn (c) (push (list expr c t) repl-history*))
+                      (fn ()
+                        (= that (eval expr) thatexpr expr)
+                        (push (list expr that) repl-history*))))
+        (editor-page (get-user req))))
+      (textarea "expr" 8 60)
+      (sp)
+      (submit))
+    (tag xmp
+      (each (expr val err) (firstn 20 repl-history*)
+        (pr "> ")
+        (ppr expr)
+        (prn)
+        (prn (if err "Error: " "")
+             (ellipsize (tostring (write val)) 800))))))
+
+(def app-filepath (app)
+  (qualified-path (string mgappdir* app)))
+
+(def app-read (app)
+  (aand (app-filepath app)
+        (file-exists it)
+        (readfile it)))
+
+(def app-write (app exprs)
+  (awhen (app-filepath app)
+    (w/outfile o it
+      (each e exprs (write e o)))))
+
+;Deleting an app will also unhook it. 
+
+(def app-delete (user app)
+  (let file (app-filepath app)
+    (if (file-exists file)
+      (do (app-unhook user app)
+          (rmfile (app-filepath app))
+          (editor-page user "Program " app " deleted."))
+      (editor-page user "No such app."))))
+
+(def app-edit (user app)
+  (whitepage
+    (pr "app:" app)
+    (br2)
+    (aform (fn (req)
+       (do (when (is (arg req "cmd") "save")
+             (app-write app (readall (arg req "exprs"))))
+           (editor-page user)))
+      (textarea "exprs" 10 82
+        (each e (app-read app)
+          (ppr e)
+          (pr "\n\n")))
+      (br2)
+      (buts 'cmd "save" "cancel"))))
+
+(def app-view (user app)
+  (whitepage
+    (pr "app:" app)
+    (br2)
+    (tag xmp (pprcode (app-read app)))
+    (br2)
+      (link "editor")))
+
+(def app-run (app)
+  (map eval (app-read app)))
+
+(def app-page (user app)
+  (whitepage
+    (pr "app:" app)
+    (br2)
+      (app-run app)
+    (br2)
+      (link "editor")))
+
+(def app-unhook (user app)
+  (= (hooks* app) nil)
+  (editor-page user nil))
+
+; The hook name and the app name (file name) are the same.
+; To use an existing News hook, name the app as the hook.
+
+(def app-hook (user app) 
+  (if (file-exists (app-filepath app))
+    (= (hooks* app) `(app-run ,app)))
+  (editor-page user nil))
+

--- a/apps/news/appeditor.arc
+++ b/apps/news/appeditor.arc
@@ -1,8 +1,7 @@
 ; App Manager: Web-based programming application based on prompt.arc
 
-(require '(
-  lib/files.arc
-  lib/srv.arc))
+(require 'lib/files.arc)
+(require 'lib/srv.arc)
 
 (= mgappdir* (qualified-path (+ srvdir* "../../managed/")))
    
@@ -24,7 +23,7 @@
     (link "logout")
 
     (when msg (hspace 10) (apply pr msg))
-
+    (pr hooks*)
     (br2)
     (aform (fn (req)
       (aif (goodname (arg req "app")) ; check if file exists

--- a/apps/news/appeditor.arc
+++ b/apps/news/appeditor.arc
@@ -44,9 +44,7 @@
             (td (hspace 40)
                 (ulink user 'delete (app-delete user app))))))
 
-    (prbold "Repl")
-
-    
+    (prbold "Repl")    
     
     (aform (fn (req) 
       (do 
@@ -55,7 +53,7 @@
                       (fn ()
                         (= that (eval expr) thatexpr expr)
                         (push (list expr that) repl-history*))))
-        (editor-page (get-user req))))
+        (editor-page (get-user req) nil)))
       (textarea "expr" 8 60)
       (sp)
       (submit))
@@ -85,7 +83,7 @@
 (def app-delete (user app)
   (let file (app-filepath app)
     (if (file-exists file)
-      (do (app-unhook user app)
+      (do (= (hooks* app) nil)
           (rmfile (app-filepath app))
           (editor-page user "Program " app " deleted."))
       (editor-page user "No such app."))))

--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,8 +1,6 @@
-(require "lib/app.arc")
-(require "lib/files.arc")
-
-(require "appeditor.arc")
-
+(require 'lib/app.arc)
+(require 'lib/files.arc)
+(require 'appeditor.arc)
 
 (= this-site*    "Anarki"
    site-url*     "http://site.example.com";your domain name
@@ -471,8 +469,9 @@
       (pr (round (/ (memory) 1000000)) " mb")
       (pr elapsed " msec")
       (link "settings" "newsadmin")
-      (link "repl")
-      (link "prompt")
+      ;(link "repl")
+      ;(link "prompt")
+      (link "editor")
       (hook 'admin-bar user whence))))
 
 (def bottom-bar ()
@@ -570,9 +569,6 @@
 
 ;    (if (bound 'posts*) (toplink "blog" "blog" label))
 ;    (if (bound 'events*) (toplink "events" "events" label))
-
-    (if (admin user) (do
-      (toplink "editor" "editor" label)))
 
     (when
       (and user (> (karma user) poll-threshold*))

--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,9 +1,7 @@
 (require "lib/app.arc")
-(require "lib/prompt.arc")
 (require "lib/files.arc")
 
-;(require (qualified-path "../events.arc"))
-;(require (qualified-path "../blog.arc"))
+(require "appeditor.arc")
 
 
 (= this-site*    "Anarki"
@@ -570,13 +568,11 @@
 ; in case anyone else was confused, 'posts* and 'events*
 ; become bound if blog.arc and events.arc are included.
 
-    (if (bound 'posts*) (toplink "blog" "blog" label))
-    (if (bound 'events*) (toplink "events" "events" label))
+;    (if (bound 'posts*) (toplink "blog" "blog" label))
+;    (if (bound 'events*) (toplink "events" "events" label))
 
     (if (admin user) (do
-      (toplink "prompt" "prompt" label)
-      (pr "&nbsp;|&nbsp;")
-      (toplink "repl" "repl" label)))
+      (toplink "editor" "editor" label)))
 
     (when
       (and user (> (karma user) poll-threshold*))

--- a/lib/prompt.arc
+++ b/lib/prompt.arc
@@ -19,7 +19,6 @@
 (def prompt-page (user . msg)
   (ensure-dir appdir*)
   (ensure-dir (string appdir* user))
-;  (ensure-dir (string appdir* "public"))
   (whitepage
     (prbold "Prompt")
     (sp)


### PR DESCRIPTION
Combined prompt and repl into one page, and updated prompt to (hopefully) better serve as a general purpose plugin and code editor. 

Apps can be assigned to and removed from the hooks table, although I couldn't get this to do anything useful or affect News in any way... the hook name is the same as the app name. 