### PR TITLE
added canonical paths, updated news

### DIFF
--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,9 +1,3 @@
-(require "lib/app.arc")
-(require "lib/prompt.arc")
-(require "lib/files.arc")
-
-;(require (qualified-path "../events.arc"))
-;(require (qualified-path "../blog.arc"))
 
 
 (= this-site*    "Anarki"
@@ -18,10 +12,13 @@
    site-color*   (color 180 180 180)
    border-color* (color 180 180 180)
    prefer-url*   t
-   newsdir*  (+ srvdir* "news/")
-   storydir* (+ srvdir* "news/story/")
-   profdir*  (+ srvdir* "news/profile/")
-   votedir*  (+ srvdir* "news/vote/")
+
+   newsdir*   (canonical-path-ts "apps/news/www/news")
+   storydir*  (canonical-path-ts "apps/news/www/news/story")
+   profdir*   (canonical-path-ts "apps/news/www/news/profile")
+   votedir*   (canonical-path-ts "apps/news/www/news/vote")
+   logdir*    (canonical-path-ts "apps/news/www/logs")
+   staticdir* (canonical-path-ts "apps/news/static")
 
 ; remember to set caching to 0 when testing non-logged-in
 
@@ -570,8 +567,8 @@
 ; in case anyone else was confused, 'posts* and 'events*
 ; become bound if blog.arc and events.arc are included.
 
-    (if (bound 'posts*) (toplink "blog" "blog" label))
-    (if (bound 'events*) (toplink "events" "events" label))
+;   (if (bound 'posts*) (toplink "blog" "blog" label))
+;   (if (bound 'events*) (toplink "events" "events" label))
 
     (if (admin user) (do
       (toplink "prompt" "prompt" label)

--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -1,5 +1,3 @@
-
-
 (= this-site*    "Anarki"
    site-url*     "http://site.example.com";your domain name
    parent-url*   "http://github.com/arclanguage/anarki"
@@ -13,12 +11,12 @@
    border-color* (color 180 180 180)
    prefer-url*   t
 
-   newsdir*   (canonical-path-ts "apps/news/www/news")
-   storydir*  (canonical-path-ts "apps/news/www/news/story")
-   profdir*   (canonical-path-ts "apps/news/www/news/profile")
-   votedir*   (canonical-path-ts "apps/news/www/news/vote")
-   logdir*    (canonical-path-ts "apps/news/www/logs")
-   staticdir* (canonical-path-ts "apps/news/static")
+   newsdir*   (canonical-path-ts  "apps/news/www/news")
+   storydir*  (canonical-path-ts  "apps/news/www/news/story")
+   profdir*   (canonical-path-ts  "apps/news/www/news/profile")
+   votedir*   (canonical-path-ts  "apps/news/www/news/vote")
+   logdir*    (canonical-path-ts  "apps/news/www/logs")
+   staticdir* (canonical-path-ts  "apps/news/static")
 
 ; remember to set caching to 0 when testing non-logged-in
 
@@ -567,8 +565,8 @@
 ; in case anyone else was confused, 'posts* and 'events*
 ; become bound if blog.arc and events.arc are included.
 
-;   (if (bound 'posts*) (toplink "blog" "blog" label))
-;   (if (bound 'events*) (toplink "events" "events" label))
+   (if (bound 'posts*) (toplink "blog" "blog" label))
+   (if (bound 'events*) (toplink "events" "events" label))
 
     (if (admin user) (do
       (toplink "prompt" "prompt" label)

--- a/apps/news/run-news.arc
+++ b/apps/news/run-news.arc
@@ -1,4 +1,4 @@
-(require 'news.arc)   ; HN style app
+(require (canonical-path "apps/news/news.arc"))   ; HN style app
 
 (thread (nsv 8080)) ; run in a thread so repl remains usable
 (sleep 3)  ; wait for nsv's initial messages to appear before printing first prompt

--- a/lib/files.arc
+++ b/lib/files.arc
@@ -1,3 +1,15 @@
+(defmemo path-separator ()
+  (if (is ($.system-type) 'windows) #\\ #\/))
+
+(defmemo canonical-path (path)
+ " builds an absolute file path from the root anarki directory "
+  ($.path->string 
+        (apply $.build-path ($.path-only $.arc-arc-path) (tokens path #\/))))
+
+(defmemo canonical-path-ts (path)
+" builds a canonical path with a trailing separator "
+  (string (canonical-path path) (path-separator)))
+
 (def mv (src dst)
   " Moves the file or directory `src' to `dst'. "
   ($.rename-file-or-directory src dst)

--- a/libs.arc
+++ b/libs.arc
@@ -12,7 +12,7 @@
     lib/collect.arc
 
 ;   ; optional
-;   lib/files.arc
+    lib/files.arc
 ;   lib/streams.arc
 ;   lib/lru-cache.arc
 ;   lib/tree.arc


### PR DESCRIPTION
Added support for canonical filepaths from the anarki root, which is apparently available from `($.path-only $.arc-arc-path) `. This should solve problems with file inclusion outside the anarki path, and with using relative paths in general. 