### PR TITLE
app generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ apps/*/logs
 # accident.
 /unit-test.arc/
 
+www/
+
 # The build-web-help.arc script generates this directory.
 /build-gh-pages/
 

--- a/apps/appcmd.arc
+++ b/apps/appcmd.arc
@@ -1,2 +1,4 @@
 (case (argv 1)
-    "app-start" (app-start (argv 2)))
+    "app-start"  (app-start  (argv 2))
+    "app-create" (app-create (argv 2)))
+    

--- a/apps/applib.arc
+++ b/apps/applib.arc
@@ -1,25 +1,66 @@
-(def app-start (name (o startfile (string "run-" name ".arc")))
-  (= appdir*    (canonical-path-ts (string "apps/" name ))
-     apprun*    (+ appdir* startfile))
+(def app-getpath (name)
+  (canonical-path-ts (string "apps/" name )))
+
+(def app-setsrv (path)
+  (= srvdir*    (+ path    "www/")
+     hpwfile*   (+ srvdir* "hpw")
+     emailfile* (+ srvdir* "emails")
+     oidfile*   (+ srvdir* "openids")
+     adminfile* (+ srvdir* "admins")
+     cookfile*  (+ srvdir* "cooks")
+     logdir*    (+ srvdir* "logs/")  
+     staticdir* (+ path    "static/")))
+
+(def app-start (name)
+  
+  (= appdir* (app-getpath name)
+     apprun* (+ appdir* (string "run-" name ".arc")))
 
   ; to match run-news,arc, each app needs an arc file
   ; named "run-" appname ".arc" 
 
   (if (file-exists apprun*)
     (do
+      (app-setsrv appdir*)
       (prn (string "starting app " name " ... "))
-  
-  ; reset the variables required by the app server 
+      (require apprun*))
+    (prn (string "bootstrap file " apprun* "not found!"))))
 
-       (= srvdir*    (+ appdir* "www/")
-          hpwfile*   (+ srvdir* "hpw")
-          emailfile* (+ srvdir* "emails")
-          oidfile*   (+ srvdir* "openids")
-          adminfile* (+ srvdir* "admins")
-          cookfile*  (+ srvdir* "cooks")
-          logdir*    (+ srvdir* "logs/")  
-          staticdir* (+ appdir* "static/"))
+(def app-create (name)
 
-        (require apprun*))
+   (= appdir* (app-getpath name) 
+      appcmd* (canonical-path "/apps/appcmd.arc"))
 
-        (prn (string "bootstrap file " apprun* "not found!"))))
+   (unless (dir-exists appdir*)
+      (app-setsrv appdir*)
+      ; create server directories and static directory
+      (ensure-srvdirs)
+      (ensure-dir (+ appdir* "static/")))
+
+    ; windows start
+    (textfile-write (string appdir* "run-" name ".cmd") 
+      "@ECHO OFF"
+      "SETLOCAL ENABLEEXTENSIONS"
+      "pushd \"%~dp0\""
+      (string "../../arc.cmd -i ../appcmd.arc \"app-start\" " "\"" name "\"")
+      "popd"
+      "ENDLOCAL")
+
+    ; linux start
+    (textfile-write (string appdir* "run-" name ".sh") 
+      "#!/bin/bash"
+      "#change to the directory of the script"
+      "cd $(dirname \"$0\")"
+      (string "../../arc.sh -i ../appcmd.arc \"app-start\" " "\"" name "\""))
+
+    ; bootstrap
+     (textfile-write (string appdir* "run-" name ".arc") 
+      (string "(require (canonical-path \"apps/" name "/" name ".arc\"))")
+      "(thread (asv 8080)) ; run in a thread so repl remains usable"
+      "(sleep 3)  ; wait for asv's initial messages to appear before printing first prompt")
+
+    ; main
+    (textfile-write (string appdir* name ".arc")
+      "(defop || req (pr \"This is the home page.\"))"))
+      
+

--- a/lib/files.arc
+++ b/lib/files.arc
@@ -57,3 +57,9 @@
   " Returns a directory tree from the given path. "
   (if (~dir-exists path) path
       (map dir-tree (map [$.path->string:$.build-path path _] (dir path)))))
+
+(def textfile-write (path . lines)
+   (w/outfile outf path 
+    (w/stdout outf
+      (each line lines 
+        (prn line)))))


### PR DESCRIPTION
A skeleton for a basic app can be generated with `(app-create name)`, and this will create the app folder, start scripts and an app file with an index defop pointing to localhost. 