### PR TITLE
removed superfluous doctype and charset

### DIFF
--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -414,10 +414,10 @@
 
 (mac npage (title . body)
   `(do 
-     (doctype "html")
+;    (doctype "html")
      (html
        (head
-         (meta-charset "UTF-8")
+;        (meta-charset "UTF-8")
          (css-ext "news.css")
          (favicon "favicon.ico")
          (meta-viewport "width=device-width")


### PR DESCRIPTION
apparently the doctype and meta charset tags weren't needed, so I've commented them out. 