### PR TITLE
only bind vote js for logged in users

### DIFF
--- a/apps/news/news.arc
+++ b/apps/news/news.arc
@@ -582,7 +582,8 @@
 
 (def topright (user whence (o showkarma t))
   (when user
-    (userlink user user nil)
+
+    (tag (span "id" "userlink") (userlink user user nil))
     (when showkarma (pr  "&nbsp;(@(karma user))"))
     (pr "&nbsp;|&nbsp;"))
   (if user

--- a/apps/news/static/news.js
+++ b/apps/news/static/news.js
@@ -1,13 +1,18 @@
 
 window.onload = function() {
-  var votelinks = byClass(document, "votelink");
-  for (var i = votelinks.length - 1; i >= 0; i--) {
-    votelinks[i].addEventListener('click', function (e) {
-      e.preventDefault();
-      vote(this);
-    }, false);
+  if(byId(document, "userlink")) {
+
+    var votelinks = byClass(document, "votelink");
+
+    for (var i = votelinks.length - 1; i >= 0; i--) {
+      votelinks[i].addEventListener('click', function (e) {
+        e.preventDefault();
+        vote(this);
+      }, false);
+    }
   }
 }
+
 
 function byId(e, id) {
   return e.getElementById(id);


### PR DESCRIPTION
Restores the redirect for non logged in users to login before voting by not binding the javascript at all unless they're logged in. 