### PR TITLE
Define UUID

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -1694,3 +1694,20 @@ Arc 3.1 documentation: https://arclanguage.github.io/ref.
     'nil
     (cons start (range (+ start 1) end))))
 (xdef range range)
+
+
+(module uuid racket/base
+  (require ffi/unsafe)
+  (provide uuid)
+
+  (define uuid
+    (get-ffi-obj "uuid_generate" (ffi-lib (if (eqv? (system-type 'os) 'macosx) "libSystem" "libuuid") '("1" ""))
+      (_fun (out : _bytes = (make-bytes 16)) -> _void -> (uuid-unparse out))))
+
+  (define uuid-unparse
+    (get-ffi-obj "uuid_unparse" (ffi-lib (if (eqv? (system-type 'os) 'macosx) "libSystem" "libuuid") '("1" ""))
+      (_fun (uuid : _bytes) (out : _bytes = (make-bytes 32)) -> _void -> (cast out _bytes _string/utf-8)))))
+
+(require 'uuid)
+
+(xdef uuid uuid)


### PR DESCRIPTION
I'm not sure if this is appropriate for anarki, but for nREPL support, it's necessary to be able to geneate UUIDs: http://arclanguage.org/item?id=20931

```
arc> (uuid)
"37E430A6-C53B-4D93-8B60-0CC006933951"
```