### PR TITLE
Let names end with syntax chars

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -161,7 +161,7 @@
   (and (symbol? x)
        (not (or (eqv? x '+) (eqv? x '++) (eqv? x '_)))
        (let ([name (symbol->string x)])
-         (has-ssyntax-char? name (- (string-length name) 1)))))
+         (has-ssyntax-char? name (- (string-length name) 2)))))
 
 (define (has-ssyntax-char? string i)
   (and (>= i 0)
@@ -285,7 +285,7 @@
                    (err "Bad ssyntax" orig)
                    (chars->value (car toks)))))]))
 
-(define (insym? char sym) (member char (symbol->chars sym)))
+(define (insym? char sym) (member char (reverse (cdr (reverse (symbol->chars sym))))))
 
 (define (symbol->chars x) (string->list (symbol->string x)))
 


### PR DESCRIPTION
This PR adds support for naming variables FOO! and BAR.

In particular, it's useful to be able to write macros like:

```
(def cat args
  (apply + "" args))

(mac cat! (var . args)
  `(= ,var (cat ,var ,@args)))
```

```
(let s ""
  (cat! s "foo")
  (cat! s " bar " 'baz)
  ...
  s)
```