### PR TITLE
Some nil fixes

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -427,7 +427,7 @@
 ;   (not destructuring), so they must be passed or be optional.
 
 (define (ac-complex-args args env ra is-params)
-  (cond [(or (eqv? args '()) (eqv? args 'nil)) '()]
+  (cond [(ar-nil? args) '()]
         [(symbol? args) (list (list args ra))]
         [(pair? args)
          (let* ([x (if (and (pair? (car args)) (eqv? (caar args) 'o))
@@ -697,7 +697,7 @@
 ; Scheme lists (e.g. . body of a macro).
 
 (define (ar-false? x)
-  (or (eq? x 'nil) (eq? x '()) (eq? x #f)))
+  (or (ar-nil? x) (eq? x #f)))
 
 ; call a function or perform an array ref, hash ref, &c
 
@@ -798,11 +798,14 @@
 (xdef nil 'nil)
 (xdef t   't)
 
+(define (ar-nil? x)
+  (or (eq? x 'nil) (null? x)))
+
 (define (all test seq)
   (or (null? seq)
       (and (test (car seq)) (all test (cdr seq)))))
 
-(define (arc-list? x) (or (pair? x) (eqv? x 'nil) (eqv? x '())))
+(define (arc-list? x) (or (pair? x) (ar-nil? x)))
 
 ; Generic +: strings, lists, numbers.
 ; Return val has same type as first argument.
@@ -1057,7 +1060,7 @@
                            (apply string-append
                                           (map (lambda (y) (ar-coerce y 'string))
                                                (ar-denil-last l))))))
-            (sym    ,(lambda (x) (if (eqv? x 'nil) "" (symbol->string x)))))
+            (sym    ,(lambda (x) (if (ar-nil? x) "" (symbol->string x)))))
 
    (sym     (string ,string->symbol)
             (char   ,(lambda (c) (string->symbol (string c)))))
@@ -1492,7 +1495,7 @@ Arc 3.1 documentation: https://arclanguage.github.io/ref.
 
 (xdef sref
   (lambda (com val ind)
-    (cond [(hash? com)  (if (eqv? val 'nil)
+    (cond [(hash? com)  (if (ar-nil? val)
                                   (hash-remove! com ind)
                                   (hash-set! com ind val))]
           [(string? com) (string-set! com ind val)]


### PR DESCRIPTION
Old behavior:
```
arc> (coerce (list) 'string)
symbol->string: contract violation
  expected: symbol?
  given: '()
arc> (= h (obj a 1))
arc> (= (h 'a) (list))
()
arc> h
#hash((a . ()))
```

New behavior:
```
arc> (coerce (list) 'string)
""
arc> (= h (obj a 1))
arc> (= (h 'a) (list))
()
arc> h
#hash()
```