### PR TITLE
Define RAISE

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -794,6 +794,7 @@
 
 (xdef is (lambda args (pairwise ar-is2 args)))
 
+(xdef raise raise)
 (xdef err err)
 (xdef nil 'nil)
 (xdef t   't)


### PR DESCRIPTION
This is necessary in order to re-raise an error.

```
(on-err (fn (c) (do-cleanup) (raise c))
        (fn () (try-something) (do-success)))
```

Note that the above example is not possible using `protect`, because `protect` unconditionally executes the same function regardless of whether the body succeeds or fails.