### PR TITLE
Read [] as %BRACKETS and {} as %BRACES

### DIFF
--- a/CHANGES/brackets
+++ b/CHANGES/brackets
@@ -1,13 +1,13 @@
 In Arc 3.1, [...] is syntax for (fn (_) (...)). This hack instead translates
-[...] into (make-br-fn (...)). This allows the semantics of [] to be redefined
+[...] into (%brackets ...). This allows the semantics of [] to be redefined
 in arc code. A simple definition is added to arc.arc that expands it to (fn (_)
 (...)), allowing the arc code in arc.arc, strings.arc, srv.arc, etc. to use []
-as before. A file load/make-br-fn.arc, which gets autoloaded when arc is
+as before. A file load/braces.arc, which gets autoloaded when arc is
 started, though after the aforementioned files are loaded, replaces this
 definition with a more powerful syntax that is almost backwards-compatible.
 
-The newer syntax interprets all variables beginning with _ found in the br-fn's
-body to be arguments to the br-fn. The order of these arguments is alphabetical,
+The newer syntax interprets all variables beginning with _ found in the body
+to be arguments to the resulting fn. The order of these arguments is alphabetical,
 so for example:
 
     arc> ([list _1 _2] 'a 'b) ; ==> ((fn (_1 _2) (list _1 _2)) 'a 'b)
@@ -38,6 +38,6 @@ that quasiquotation is not (yet!) handled. So for example:
     arc> ([list `_foo _] 1) ; quasiquoted things are _not_
     Error: "#<procedure>: expects 2 arguments, given 1: 1"
 
-Another finnicky case is nested br-fns. I suggest avoiding these altogether, but
+Another finnicky case is nested brackets. I suggest avoiding these altogether, but
 if you *must* use them, then as long as you use no underscore-prefixed symbols
 within them except '_ itself, it should work exactly as in Arc 3.1.

--- a/ac.rkt
+++ b/ac.rkt
@@ -108,7 +108,7 @@
 
 (defarc (ac s env)
   (cond [(string? s) (ac-string s env)]
-        [(literal? s) s]
+        [(literal? s) (list 'quote s)]
         [(eqv? s 'nil) (list 'quote 'nil)]
         [(ssyntax? s) (ac (expand-ssyntax s) env)]
         [(symbol? s) (ac-var-ref s env)]

--- a/arc.arc
+++ b/arc.arc
@@ -279,10 +279,15 @@ function 'f' to them."
   (pair '(10 2 3 40 50 6) max)
   (10 40 50))
 
-(mac make-br-fn (body)
+(mac %brackets body
 "The function invoked on square-bracket calls.
-For example, [car _] => (make-br-fn (car _)) => (fn (_) (car _))"
+For example, [car _] => (%brackets car _) => (fn (_) (car _))"
   `(fn (_) ,body))
+
+(mac %braces body
+"The function invoked on curly-bracket calls.
+For example, {a 1 b 2} => (%braces a 1 b 2) => (obj a 1 b 2)"
+  `(obj ,@body))
 
 (mac and args
 "Stops at the first argument to fail (return nil). Returns the last argument before stopping."

--- a/brackets.rkt
+++ b/brackets.rkt
@@ -5,7 +5,7 @@
 ;> (require "brackets.rkt")
 ;> (current-readtable bracket-readtable)
 ;> '([+ _ 1] 10)
-;'((make-br-fn (+ _ 1)) 10)
+;'((%brackets + _ 1) 10)
 
 
 (provide
@@ -18,13 +18,16 @@
 ; but nested reads still use the curent readtable:
 
 (define (read-square-brackets ch port src line col pos)
-  `(make-br-fn
-     ,(read/recursive port #\[ #f)))
+  `(%brackets ,@(read/recursive port #\[ #f)))
+
+(define (read-curly-braces ch port src line col pos)
+  `(%braces ,@(read/recursive port #\{ #f)))
 
 ; a readtable that is just like the builtin except for []s
 
 (define bracket-readtable
-  (make-readtable #f #\[ 'terminating-macro read-square-brackets))
+  (make-readtable #f #\[ 'terminating-macro read-square-brackets
+                     #\{ 'terminating-macro read-curly-braces))
 
 ; these two implement the required functionality for #reader
 

--- a/lib/brackets.arc
+++ b/lib/brackets.arc
@@ -1,5 +1,5 @@
 ; avoid redefinition warning
-($ (namespace-undefine-variable! (ac-global-name 'make-br-fn)))
+($ (namespace-undefine-variable! (ac-global-name '%brackets)))
 
 (def -mbf-argsym (e)
   (and (begins string.e "_")
@@ -19,11 +19,11 @@
                (consif (when flag sym)
                        (rem sym old))))
 
-; better make-br-fn
+; better %brackets
 ;   treats any symbols starting with '_' as args, ordered alphabetically
 ;     e.g. _1, _2, _3, or _a, _b, _c, etc.
 ;   treats __ as the rest arg
-(mac make-br-fn (body)
+(mac %brackets body
   (let args '__
     (each arg (dedup:sort > -mbf-argsyms.body)
       (pushnew arg args))

--- a/lib/ppr.arc
+++ b/lib/ppr.arc
@@ -16,14 +16,16 @@
 
 (def print (x)
   " Print an expression on one line, replacing quote, unquote,
-    quasiquote, unquote-splicing, and make-br-fn with their respective symbols. " 
+    quasiquote, unquote-splicing, %brackets, and %braces with their respective symbols. " 
   (do (aif (or atom.x dotted.x (isa x 'string))
              write.x
            (pprsyms* car.x)
              (do pr.it
                (print cadr.x))
-           (is car.x 'make-br-fn)
-             (do (pr "[") (print-spaced cadr.x) (pr "]"))
+           (is car.x '%brackets)
+             (do (pr "[") (print-spaced cdr.x) (pr "]"))
+           (is car.x '%braces)
+             (do (pr "{") (print-spaced cdr.x) (pr "}"))
            (do (pr "(") print-spaced.x (pr ")")))
       x))
 
@@ -164,11 +166,16 @@
          (do (unless noindent sp.col)
              print.x
              nil)
-       (is car.x 'make-br-fn)           ;if the expression is a br-fn, print the brackets and then the contents
+       (is car.x '%brackets)           ;if the expression is %brackets, print the brackets and then the contents
          (ppr-sub
            (pr "[")
-           (ppr-main cadr.x (+ col 1) t)
+           (ppr-main cdr.x (+ col 1) t)
            (pr "]"))
+       (is car.x '%braces)           ;if the expression is %braces, print the braces and then the contents
+         (ppr-sub
+           (pr "{")
+           (ppr-main cdr.x (+ col 1) t)
+           (pr "}"))
        (pprsyms* car.x)
          (ppr-sub
            pr.it

--- a/libs.arc
+++ b/libs.arc
@@ -8,7 +8,7 @@
     lib/queue.arc
     lib/tem.arc
     lib/declare.arc
-    lib/make-br-fn.arc
+    lib/brackets.arc
     lib/collect.arc
 
 ;   ; optional


### PR DESCRIPTION
http://arclanguage.org/item?id=20985

- rename `make-br-fn` to `%brackets`
- read `[foo bar]` as `(%brackets foo bar)`
- read `{a 1 b 2}` as `(%braces a 1 b 2)`
- the default implementation of `%braces` is the `obj` macro