### PR TITLE
Various work

### DIFF
--- a/arc.arc
+++ b/arc.arc
@@ -2002,7 +2002,7 @@ Name comes from (cons 1 2) being printed with a dot: (1 . 1)."
 (def read-table ((o i (stdin)))
 "Reads an association list from a stream 'i' (stdin by default) and turns it
 into a table."
-  (let e (read i)
+  (let e (read-data i)
     (if (alist e) (listtab e) e)))
 
 (def load-tables (file)
@@ -2018,7 +2018,7 @@ of tables."
 
 (def write-table (h (o o (stdout)))
 "Writes table as an association list to stream 'o' (stdout by default)."
-  (write tablist.h o))
+  (write-data tablist.h o))
 
 ; Optional predicate-based typing
 
@@ -2864,8 +2864,14 @@ of 'x' by calling 'self'."
     (readstring1 x)
     (unserialize:sread x)))
 
+(def read-data ((o port (stdin)))
+  (quoted:read port))
+
 (def write (x (o port (stdout)))
   (swrite serialize.x port))
+
+(def write-data (x (o port (stdin)))
+  (write unquoted.x port))
 
 (= hooks* (table))
 

--- a/lib/tem.arc
+++ b/lib/tem.arc
@@ -65,7 +65,7 @@ from template 'tem-type'."
   (save-file (temlist tem val) file))
 
 (def temread (tem (o str (stdin)))
-  (let fields (read str)
+  (let fields (read-data str)
     (unless (is fields eof)
       (listtem tem fields))))
 


### PR DESCRIPTION
- Arc lists are now scheme lists. No more niltree/denil
- Use racket's REPL, letting users type ^C without exiting the program (this is handy for interrupting a long-running computation)
- Add a STR function that prints things out nicely[1]

[1] ... well, for some definition of "nicely".


This PR should *not* be merged. I'm submitting it because it's mostly-working and it has some interesting ideas. The STR function
spits out a string like this:

```
["%tag", "tem", ["item", {by: "shawn", 
               id: 140, 
               ip: "2600:6c40:5e00:1714:0:8f0e:424f:e94d", 
               keys: ["nokill", "/l/scp", "/l/writing", "/l/humor"], 
               kids: [141], 
               score: 1, 
               sockvotes: 0, 
               text: "", 
               time: 1545781744, 
               title: "SCP-1933", 
               type: "story", 
               url: "http://www.scp-wiki.net/scp-1933", 
               votes: [[1545781744, "2600:6c40:5e00:1714:0:8f0e:424f:e94d", "shawn", "up", 0]]}, {}]]()
```


Obviously this isn't readable by racket, and it's not readable by a JSON reader, ~and it's not very readable by humans~~.

Feel free to "test" this "dev version", if you dare. It's kind of neat in some ways but kind of bad in other ways.