### PR TITLE
file loading and require updates

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -1413,8 +1413,8 @@ Arc 3.1 documentation: https://arclanguage.github.io/ref.
     (aload filename)))
 
 ;create a normalized, absolute path from the Arc install, 
-;where p is a relative path.
-
+;where p is a relative path. The returned path will not
+;be case insensitive. 
 (define (normalize-path p)
   (simple-form-path 
     (apply build-path 
@@ -1426,15 +1426,19 @@ Arc 3.1 documentation: https://arclanguage.github.io/ref.
         (string-replace (~a p) "\\" "/") 
       "/")))))
 
-(define arc-loaded-files (make-hash))
+(xdef required-files* (make-hash))
+(define (arc-required-files)
+  (namespace-variable-value (ac-global-name 'required-files*)))
 
-; 
+(define (list-required-files)
+  (hash-values (arc-required-files)))
+
 (define (aload-unique p)
   (let* ([np (~a (normalize-path p)) ]
-         [k  (md5 (string-downcase np))])
-    (and (file-exists? np) (not (hash-has-key? arc-loaded-files k))
+         [k  (string-downcase np)])
+    (and (file-exists? np) (not (hash-has-key? (arc-required-files) k))
       (begin
-        (hash-set! arc-loaded-files k np)
+        (hash-set! (arc-required-files) k np)
         (aload np)))))
 
 (define (test filename)

--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -1,0 +1,8 @@
+# ignore everything but the app files and news
+*
+
+!.gitignore
+!appcmd.arc
+!appeditor.arc
+!applib.arc
+!news/*

--- a/apps/appeditor.arc
+++ b/apps/appeditor.arc
@@ -1,6 +1,6 @@
 ; managed script editor, based on prompt.arc
 
-(= mgappdir* (canonical-path-ts "/apps/managed"))
+(= mgappdir* "apps/managed")
    
 (defop appeditor req
   (let user (get-user req)

--- a/apps/applib.arc
+++ b/apps/applib.arc
@@ -1,5 +1,5 @@
 (def app-getpath (name)
-  (canonical-path-ts (string "apps/" name )))
+  (string "apps/" name "/"))
 
 (def app-setsrv (path)
   (= srvdir*    (+ path    "www/")
@@ -12,24 +12,24 @@
      staticdir* (+ path    "static/")))
 
 (def app-start (name)
-  
+  "Starts application (name). ex: (app-start \"news\")"
   (= appdir* (app-getpath name)
      apprun* (+ appdir* (string "run-" name ".arc")))
 
   ; to match run-news,arc, each app needs an arc file
   ; named "run-" appname ".arc" 
 
-  (if (file-exists apprun*)
+  (if (file-exists ($.normalize-path apprun*))
     (do
-      (app-setsrv appdir*)
-      (prn (string "starting app " name " ... "))
+      (app-setsrv (string appdir* (path-separator))) ; this needs the end separator
+      (prn (string "starting app " name " from " appdir*))
       (require apprun*))
     (prn (string "bootstrap file " apprun* "not found!"))))
 
 (def app-create (name)
-
+  "Creates a skeleton web application."
    (= appdir* (app-getpath name) 
-      appcmd* (canonical-path "/apps/appcmd.arc"))
+      appcmd* ($.normalize-path "/apps/appcmd.arc"))
 
    (unless (dir-exists appdir*)
       (app-setsrv appdir*)
@@ -55,7 +55,7 @@
 
     ; bootstrap
      (textfile-write (string appdir* "run-" name ".arc") 
-      (string "(require (canonical-path \"apps/" name "/" name ".arc\"))")
+      (string "(require \"apps/" name "/" name ".arc\")")
       "(thread (asv 8080)) ; run in a thread so repl remains usable"
       "(sleep 3)  ; wait for asv's initial messages to appear before printing first prompt")
 

--- a/apps/news/run-news.arc
+++ b/apps/news/run-news.arc
@@ -1,4 +1,4 @@
-(require (canonical-path "apps/news/news.arc"))   ; HN style app
-(require (canonical-path "apps/appeditor.arc")); app editor
+(require "apps/news/news.arc")   ; HN style app
+(require "apps/appeditor.arc"); app editor
 (thread (nsv 8080)) ; run in a thread so repl remains usable
 (sleep 3)  ; wait for nsv's initial messages to appear before printing first prompt

--- a/lib/files.arc
+++ b/lib/files.arc
@@ -3,8 +3,7 @@
 
 (defmemo canonical-path (path)
  " builds an absolute file path from the root anarki directory "
-  ($.path->string 
-        (apply $.build-path ($.path-only $.arc-arc-path) (tokens path #\/))))
+  ($.normalize-path path ))
 
 (defmemo canonical-path-ts (path)
 " builds a canonical path with a trailing separator "

--- a/lib/require.arc
+++ b/lib/require.arc
@@ -2,7 +2,3 @@
 "loads file(s) if they have not been required."
   (each file (check files alist (list files))
     ($.aload-unique (string file) )))
-
-(def list-required-files ()
-  "returns a list of the absolute filepaths loaded by requre."
-  ($.hash-values $.arc-loaded-files))

--- a/lib/require.arc
+++ b/lib/require.arc
@@ -1,13 +1,8 @@
-(unless (and (bound 'required-files*) required-files*)
-  (= required-files* (table)))
-
 (def require (files)
-  " Loads `file(s)' if it/they has not yet been `require'd.  (Can be fooled by changing
-    the name ((require \"foo.arc\") as opposed to (require \"./foo.arc\")), but
-    this should not be a problem.)
-    See also [[load]]. "
+"loads file(s) if they have not been required."
   (each file (check files alist (list files))
-    (zap string file)
-    (or (required-files* file)
-      (do (set required-files*.file)
-          (load file)))))
+    ($.aload-unique (string file) )))
+
+(def list-required-files ()
+  "returns a list of the absolute filepaths loaded by requre."
+  ($.hash-values $.arc-loaded-files))


### PR DESCRIPTION
This is a reasonably large change so I'm definitely waiting for feedback.

I moved the behavior of require, which checked loaded files against a hashmap, into the compiler itself. A new function, `($.aload-unique file)` will resolve a canonical path to the file, lowercase it and use the md5 value of the path as a key to check against future loads. This should resolve the issue previously mentioned in (require) where different paths and different cases could result in loading the same file twice. 

It may be worth noting that all paths called by (require) should be relative to the Anarki install path. This shouldn't change much, because (require 'libs/whatever) will still work as before, but the code now validates that the path exists from that root to begin with. 

This also potentially deprecates some Arc functions, which I haven't removed yet. There is an added function in ac,rkt `($.list-required-files)` which will list the paths of all included files. This might be useful for benchmarking or debugging in the future.

Speaking of which, I haven't benchmarked this, I'm just assuming it's faster to do from racket directly than through Arc. 

The original function of (load) in arc.arc remains unchanged. I didn't add this functionality to load in arc.arc because I wanted to use the md5 and path functions from racket, and arc.arc doesn't appear to use any racket interop. 

I've run the test suite, News and tested creating a new app (I need to add documentation for that) and everything seems to work. (edit: except for one test :/)