### PR TITLE
re-add normalize-path

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -1463,6 +1463,20 @@ Arc 3.1 documentation: https://arclanguage.github.io/ref.
 (define (arc-required-files)
   (namespace-variable-value (ac-global-name 'required-files*)))
 
+;create a normalized, absolute path from the Arc install, 
+;where p is a relative path. The returned path will not
+;be case insensitive. 
+(define (normalize-path p)
+  (simple-form-path 
+    (apply build-path 
+      (path-only arc-arc-path)
+; to get a list of path segments, we need to normalize slashes,
+; split on those slashes, then remove any blank elements.
+   (remove* (list "") 
+      (string-split 
+        (string-replace (~a p) "\\" "/") 
+      "/")))))
+
 (define (list-required-files)
   (hash-values (arc-required-files)))
 


### PR DESCRIPTION
Reverting the previous commit because apparently Racket's version of normalize-path doesn't work exactly the way News expects it to. 