### PR TITLE
Add support for themes

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -1,8 +1,1 @@
 # ignore everything but the app files and news
-*
-
-!.gitignore
-!appcmd.arc
-!appeditor.arc
-!applib.arc
-!news/*

--- a/apps/news/static/dark.css
+++ b/apps/news/static/dark.css
@@ -1,0 +1,20 @@
+@import url("layout.css");
+
+body {
+    background-color: #000;  
+    color:#aaa;
+}
+
+a:link    {color:#8f99d1;}
+a:visited {color:#828282;}
+.page-header,.page-footer {background-color:#272424;}
+.page-content {background-color: #121212;}
+.subtext a:link, .subtext a:visited {color: #828282;}
+.comhead a:link, .subtext a:visited {color:#828282;}
+.uplink a:link{color: #82dd82;}
+.downlink a:link {color: #dd8282;}
+.dead {color:#dddddd;}
+.sand {background-color: rgb(246, 246, 239);}
+.noob {color:#3c963c;}
+.banned {color:#400000;}
+.editor {color:#000040;}

--- a/apps/news/static/default.css
+++ b/apps/news/static/default.css
@@ -1,0 +1,20 @@
+@import url("layout.css");
+
+body {
+    background-color: #ffffff;  
+    color:#000000;
+}
+
+a:link    {color:#000000;}
+a:visited {color:#828282;}
+.page-header,.page-footer {background-color:#ddd;}
+.page-content {background-color: #f6f6ef;}
+.subtext a:link, .subtext a:visited {color: #828282;}
+.comhead a:link, .subtext a:visited {color:#828282;}
+.uplink a:link{color: #82dd82;}
+.downlink a:link {color: #dd8282;}
+.dead {color:#dddddd;}
+.sand {background-color: rgb(246, 246, 239);}
+.noob {color:#3c963c;}
+.banned {color:#400000;}
+.editor {color:#000040;}

--- a/apps/news/static/layout.css
+++ b/apps/news/static/layout.css
@@ -1,0 +1,163 @@
+body  { 
+	font-family:Verdana, sans-serif; 
+	font-size:12pt;
+}
+
+a:link, a:visited { 
+	text-decoration: none;
+}
+
+form {
+	padding-top:1em;
+	padding-bottom:3em;
+	padding-left:2em;
+}
+
+.layout {
+	width:85%;
+	min-width:85%;
+	margin:0px auto;
+	display:block;
+}
+
+.page-header,.page-footer {
+    display: block;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    height: 18px;
+    font-size: 80%;
+    margin: 0 auto;
+    padding-left: 2px;
+}
+
+.topnav {
+
+}
+
+#logo {
+	margin-right:4px;
+}
+
+#page-title {
+	position:relative;
+	bottom:4px;
+	font-weight:bold;
+}
+
+.comtitle {
+	
+}
+
+#navmain {
+	width:auto;
+	padding-left:1em;
+	position:relative;
+	height:10px;
+	border:0;
+	margin-top:0;
+	margin-bottom:0;
+	bottom:4px;
+}
+
+#navright {
+	float:right;
+	margin-right:0.5em;
+	padding-left:1em;
+}
+
+.page-content {
+	font-size: 80%;
+	padding-top:1em;
+	padding-bottom:1em;
+	padding-left:2em;
+	padding-right:5em;
+	line-height:150%;
+
+}
+
+.comments-list, .threads-list {
+  margin-left:2em;
+  padding-left:0px;
+  margin-bottom:1em;
+}
+
+.comments-list li, .threads-list li {
+	list-style-type:none;
+	margin-top:1em;
+	margin-bottom:1em;
+	margin-left:1em;
+}
+
+.items-list {
+	padding-top: 0;
+	padding-left: 2em;
+	margin-top: 0;
+}
+
+.items-list li {
+	margin-bottom:0.5em;
+	margin-top:0;
+}
+
+.itemhead {
+	font-size:100%;
+	margin-bottom:0.2em;
+} 
+
+.comhead { 
+	font-size:85%;
+}
+
+.comment {
+	padding-top: 0.5em;
+	padding-bottom: 0.25em;
+	margin-left: 1.4em;
+	font-size: 90%;
+}
+
+.comfoot {
+	font-size: 85%;
+	margin-left: 1.5em;
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+}
+
+.comfoot a:link {
+	text-decoration:underline;
+}
+
+.subtext {
+	font-size:85%;
+	position:relative;
+	left:1.4em;
+}
+
+.itemtext {
+	padding:1em;
+	font-size:90%;
+	line-height:150%;
+}
+
+.votelinks {
+	display:inline;
+	float:left;
+	margin-right:0.2em;
+}
+
+.page-footer {
+	text-align:center;
+}
+
+.comhead a:hover { 
+	text-decoration:underline; 
+}
+
+.opcomment { 
+	font-weight:bold;
+}
+
+.comment-0 { opacity:1; }
+.comment-1 { opacity:0.5; filter:alpha(opacity=50);}
+.comment-2 { opacity:0.4; filter:alpha(opacity=40);}
+.comment-3 { opacity:0.3; filter:alpha(opacity=30);}
+.comment-4 { opacity:0.2; filter:alpha(opacity=20);}


### PR DESCRIPTION
Allows support for themes, selectable through the user panel. I basically just divided the news stylesheet between layout and theme css, and added a quick dark theme. 

ATM there doesn't seem to be a way to add select menus to the user panel so you have to enter a number for the theme - 0 or any invalid value is default, 1 is the dark theme. Add new themes by copying and changing a theme file and adding the filename to the list of themes in news.arc.  