### PR TITLE
Para always has a closing tag, add sctag.

### DIFF
--- a/lib/html.arc.t
+++ b/lib/html.arc.t
@@ -1,5 +1,43 @@
 (suite html
        (test id-is-a-string
              (assert-same "<div id=\"this-is-an-id\"></div>"
-                          (tostring (tag (div id "this-is-an-id"))))))
+                          (tostring (tag (div id "this-is-an-id")))))
 
+       (suite para
+              (test empty-para
+                    (assert-same "<p></p>"
+                                 (tostring (para))))
+              (test para-body
+                    (assert-same "<p>other stuff</p>"
+                                 (tostring (para "other stuff")))))
+
+       (suite sctag
+              (test bare
+                    (assert-same "<abcd />"
+                                 (tostring (sctag abcd))))
+              (test spec-list-just-name
+                    (assert-same "<abcd />"
+                                 (tostring (sctag (abcd)))))
+              (test spec-list-with-contents
+                    (assert-same "<abcd efgh=\"ijkl\" mnop=\"qrst\" />"
+                                 (tostring (sctag (abcd efgh "ijkl" mnop "qrst"))))))
+
+       (suite start-tag
+              (test empty
+                    (assert-same "<abcd>"
+                                 (tostring (eval (start-tag 'abcd)))))
+              (test empty-self-close
+                    (assert-same "<abcd />"
+                                 (tostring (eval (start-tag 'abcd t)))))
+              (test opts-are-strings
+                    (assert-same "<abcd class=\"efgh\">"
+                                 (tostring (eval (start-tag '(abcd class "efgh"))))))
+              (test opts-are-strings-self-close
+                    (assert-same "<abcd class=\"efgh\" />"
+                                 (tostring (eval (start-tag '(abcd class "efgh") t)))))
+              (test opts-not-strings
+                    (assert-same "<abc def=\"ghi\">"
+                                 (tostring (eval (start-tag '(abc def "ghi"))))))
+              (test opts-not-strings-self-close
+                    (assert-same "<abc def=\"ghi\" />"
+                                 (tostring (eval (start-tag '(abc def "ghi") t)))))))


### PR DESCRIPTION
Also add a few tests around html generation.

I'm making this a PR so I can look at it when it's not late, and also because this slightly changes the `para` function. Previously, it never put an ending tag.

```
(para "hi there")
=>
<p>hi there
```

Now, it results in:
```
<p>hi there</p>
```

Closing tags are [sometimes required](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) by the html spec. Anarki never put them in, even when required. Now it always will.

This also adds self-closed tags, like

```
<br />
```

This is allowed in void elements, and required in foreign elements (see [the spec](https://html.spec.whatwg.org/multipage/syntax.html#start-tags)). Even though they are optional in void elements, I find it much more readable to know that these elements do not have a body.