### PR TITLE
In the Travis CI script, stop fetching unit-test.arc from Bitbucket.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,12 @@ before_install:
 
 install:
   # We obtain the unit test dependencies.
-  - hg clone https://bitbucket.org/zck/unit-test.arc
-  - cd unit-test.arc
-  - hg update v1.0
-  - cd ..
+  # (Currently, there are no dependencies; unit-test.arc is now part
+  # of this repo.)
+#  - hg clone https://bitbucket.org/zck/unit-test.arc
+#  - cd unit-test.arc
+#  - hg update v1.0
+#  - cd ..
 
 script:
   # We test that the Racket package installs and sets up properly, and


### PR DESCRIPTION
It seems unit-test.arc it no longer exists at the location we were fetching it from. It's been part of this repo for a while now.

This issue seems to be holding up #183.