### PR TITLE
unit-test.arc repo location has moved.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ install:
   # We obtain the unit test dependencies.
   # (Currently, there are no dependencies; unit-test.arc is now part
   # of this repo.)
-#  - hg clone https://bitbucket.org/zck/unit-test.arc
+#  - hg clone https://hg.sr.ht/~zck/unit-test.arc
 #  - cd unit-test.arc
 #  - hg update v1.0
 #  - cd ..

--- a/lib/ppr.arc
+++ b/lib/ppr.arc
@@ -128,7 +128,7 @@
       (sp (+ col 2))
       (indent-pairs (nthcdr n xs) (+ col 2))))
 
-; Support for the 'suite macro in https://bitbucket.org/zck/unit-test.arc
+; Support for the 'suite macro in https://hg.sr.ht/~zck/unit-test.arc
 (def indent-suite (xs (o col 0))
   (print-spaced (firstn 1 xs))
   (let suite-name-len (len xs.0)

--- a/old-tests.arc
+++ b/old-tests.arc
@@ -1,4 +1,4 @@
-;; unit tests in various styles prior to https://bitbucket.org/zck/unit-test.arc
+;; unit tests in various styles prior to https://hg.sr.ht/~zck/unit-test.arc
 
 ; tests from conanite's rainbow
 (require '(


### PR DESCRIPTION
Bitbucket stopped supporting mercurial. I moved the repo to https://hg.sr.ht/~zck/unit-test.arc.

This PR updates all references in this repo.