### PR TITLE
Fix some overly restrictive tests.

### DIFF
--- a/arc.arc.t
+++ b/arc.arc.t
@@ -294,20 +294,24 @@
              (assert-nil (before 6 5 '(1 2 3 4)))))
 
 (suite serialize
+       (setup sort-tagged-table
+         [do (zap copy _)
+             (zap [sort (compare < !0) _] _.2)
+             _])
        (test nil (assert-nil (serialize ())))
        (test lists
              (assert-same '(1 2 3) (serialize '(1 2 3))))
        (test strings
              (assert-same "abc" (serialize "abc")))
        (test tables
-             (assert-same '(tagged table ((3 4) (1 2)))
-                          (serialize (obj 1 2 3 4))))
+             (assert-same '(tagged table ((1 2) (3 4)))
+                          (sort-tagged-table (serialize (obj 1 2 3 4)))))
        (test tables-inside-lists
              (assert-same '(1 (tagged table ()) 2 3)
                           (serialize `(1 ,(table) 2 3))))
        (test nested-tables
-             (assert-same '(tagged table ((2 3) (1 (tagged table ()))))
-                          (serialize (obj 1 (table) 2 3)))))
+             (assert-same '(tagged table ((1 (tagged table ())) (2 3)))
+                          (sort-tagged-table (serialize (obj 1 (table) 2 3))))))
 
 (suite deserialize
        (test nil

--- a/lib/tests/core-typing-test.arc
+++ b/lib/tests/core-typing-test.arc
@@ -66,11 +66,9 @@
                             (test hex-string-with-E
                                   (assert-same 62 (coerce "3E" 'int 16)))
                             (test coerce-positive-infinity-to-int
-                                  (assert-error (coerce "+inf.0" 'int)
-                                                "inexact->exact: no exact representation\n  number: +inf.0"))
+                                  (assert-error (coerce "+inf.0" 'int)))
                             (test coerce-negative-infinity-to-int
-                                  (assert-error (coerce "-inf.0" 'int)
-                                                "inexact->exact: no exact representation\n  number: -inf.0")))
+                                  (assert-error (coerce "-inf.0" 'int))))
                      (suite string->num
                             (test rational
                                   (assert-same 3/4 (coerce "3/4" 'num)))


### PR DESCRIPTION
Four unit tests were causing pull request #183 to have a build failure on Racket 7.9 [cs].

Two tests were failing because an error message changed, and two were failing because the iteration order of hash tables changed (likely in Racket 7.7).