### PR TITLE
When opening a file, expand user directories.

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -1006,10 +1006,13 @@
 
 (xdef call/ec call-with-escape-continuation)
 
-(xdef infile  open-input-file)
+(xdef infile (lambda (f . args)
+               (apply open-input-file
+                      (expand-user-path f)
+                      args)))
 
 (xdef outfile (lambda (f . args)
-                 (open-output-file f
+                 (open-output-file (expand-user-path f)
                                    ;#:mode 'text
                                    #:exists (if (equal? args '(append))
                                        'append


### PR DESCRIPTION
We use the racket function expand-user-path to expand ~/ to the user's
home directory. We call this function for both infiles and outfiles.

This can be tested with `(outfile "~/test.txt")`. You should see something like this:
```#<output-port:/home/zck/test.txt>```

Infiles only work if the file exists. Here's a way to print out all lines of a file:

```
(w/infile file "~/test.txt" (whilet line (readline file) (prn line)))
```

Obviously, both fully qualified names and relative names should continue to work:

```
arc> (outfile "/tmp/test.txt")
#<output-port:/tmp/test.txt>

arc> (outfile "test.txt")
#<output-port:/home/zck/programs/arc/anarki/test.txt>
```

I'd like to have this tested on Windows; I've tested it on Linux.

Also, I'd be interested to see if this can be unit tested. I'm not especially sure how to at the moment.