### PR TITLE
Fix the mismatch of parens in inferior-arc.el

### DIFF
--- a/extras/inferior-arc.el
+++ b/extras/inferior-arc.el
@@ -95,7 +95,7 @@
     (define-key m "\M-\C-x" 'arc-send-definition) ;gnu convention
     (define-key m "\C-x\C-e" 'arc-send-last-sexp)
     (define-key m "\C-c\C-l" 'arc-load-file)
-    (define-key m (kbd "C-c C-q" #'arc-quit))
+    (define-key m (kbd "C-c C-q") #'arc-quit)
     m))
 
 (defvar arc-program-name "arc.sh -n"


### PR DESCRIPTION
The right paren is in a wrong position, fixed it.