### PR TITLE
Migrate from requestbin to httpstat.us

### DIFF
--- a/lib/client.arc.t
+++ b/lib/client.arc.t
@@ -39,7 +39,7 @@
                     (assert-same "Cookie: name=value; name2=value2; Expires=Wed, 09 Jun 2021;"
                                  (encode-cookies (list "name" "value" "name2" "value2" "Expires" "Wed, 09 Jun 2021")))))
        (suite send-request
-              (test ping-httpbin
+              (test get-200
                     (assert-same "HTTP/1.1 200 OK"
-                                 (caar (mkreq "www.httpbin.org/status/200"))))))
+                                 (caar (mkreq "https://httpstat.us/200"))))))
 

--- a/lib/client.arc.t
+++ b/lib/client.arc.t
@@ -41,5 +41,5 @@
        (suite send-request
               (test get-200
                     (assert-same "HTTP/1.1 200 OK"
-                                 (caar (mkreq "https://httpstat.us/200"))))))
+                                 (caar (mkreq "httpstat.us/200"))))))
 


### PR DESCRIPTION
requestbin has been having problems -- the 200 endpoint is returning 504s. I'd like to see if httpstat.us is better.