### PR TITLE
`ac.rkt`: handle `trash-whitespace` errors – fixes #60 + #199

### DIFF
--- a/ac.rkt
+++ b/ac.rkt
@@ -1446,9 +1446,10 @@ Arc 3.2 documentation: https://arclanguage.github.io/ref.
 
 
 (define (trash-whitespace)
-  (when (and (char-ready?) (char-whitespace? (peek-char)))
-    (read-char)
-    (trash-whitespace)))
+  (with-handlers ([exn:fail:contract? (lambda (exn) (void))])
+    (when (and (char-ready?) (char-whitespace? (peek-char)))
+      (read-char)
+    (trash-whitespace))))
 
 (define (tl2 interactive?)
   (when interactive? (display "arc> "))

--- a/ac.rkt
+++ b/ac.rkt
@@ -1449,7 +1449,7 @@ Arc 3.2 documentation: https://arclanguage.github.io/ref.
   (with-handlers ([exn:fail:contract? (lambda (exn) (void))])
     (when (and (char-ready?) (char-whitespace? (peek-char)))
       (read-char)
-    (trash-whitespace))))
+      (trash-whitespace))))
 
 (define (tl2 interactive?)
   (when interactive? (display "arc> "))


### PR DESCRIPTION
Firstly, thanks to everyone maintaining this fork of Arc – I've been using it to run a music aggregator and it's awesome.

However, I noticed that even a single request may saturate the CPU for multiple seconds, while filling the console with the following errors.

```
char-whitespace?: contract violation
   expected: char?
   given: #<eof>
   context...:
    /opt/textural/ac.rkt:1448:0: trash-whitespace
    /opt/textural/ac.rkt:1463:4
```

Refactoring the `trash-whitespace` function to handle the contract errors killed both birds with one stone!